### PR TITLE
fix: Fixing M3 issues

### DIFF
--- a/Target/0/three_x_plus_1_v3.tgt
+++ b/Target/0/three_x_plus_1_v3.tgt
@@ -1,0 +1,101 @@
+int sum;
+int sum2;
+sum = 0;
+sum2 = 0;
+
+
+
+int x;
+int i;
+for(i = 1, i < 32, i = i++)
+{
+    x = i;
+    while (not(x == 1))
+    {
+        int j;
+        for ( j = 1, j < 3, j = j++)
+        {
+            if (x % 2 == 0)
+            then {
+                x = x / 2;
+            } else {
+                x = 3 * x + 1;
+            };
+        };
+        sum = sum + 3;
+    };
+};
+
+
+
+int sum1;
+sum1 = 0;
+int x;
+int m;
+
+for (m = 15, m > 1, m = --m) {
+    x = m;
+    while (not(x==1)) {
+        int n;
+        for (n = 1, n < 3, n = ++n)
+        {
+            if ( x % 2 == 0)
+           then {
+                x = x / 2;
+            }
+            else
+            {
+                x = 3 * x + 1;
+            };
+        };
+        sum1 = sum1 + 3;
+    };
+};
+print (sum1);
+
+
+
+
+x = 0;
+int i;
+for (i = -24, i < -1, i = ++i) {
+    x = i;
+    while (not(x == 1) ) {
+        int j;
+        for ( j = 1, j < 3, j = ++j ) {
+            if ( x % 2 == 0 ) 
+            then {
+                x = | x/2 |;
+            }
+            else 
+            {
+                x = ( |3 * x| + 1);
+            };
+        };
+        sum2 = ((sum2 + 3));
+    };
+};
+print(sum2);
+
+print(sum);
+
+if (sum2 == 423 && not(sum != 888)) then {
+    if (sum2 + 465 >= sum && sum <= sum2 + 465)  then {
+        if (2 ^ 0 < 2 && 2 ^ 1 > 2 || 2 ^ 3 < 8) 
+        then {
+            print ( 1 );
+        }
+        else 
+        {
+            print ( 2 ) ;
+        };
+    }
+    else 
+    {
+        print ( 3 ) ;
+    };
+}
+else 
+{
+    print ( 4 ) ;
+};

--- a/Transformation/SML_Modules/Interpreter/semantics.sml
+++ b/Transformation/SML_Modules/Interpreter/semantics.sml
@@ -516,7 +516,7 @@ fun E( itree(inode("Express",_),
         end
 
   (* Value *)
-  | E( itree(inode("value",_),
+  | E( itree(inode("Value",_),
                 [
                     itree(inode("true",_), [] )
                 ]
@@ -524,7 +524,7 @@ fun E( itree(inode("Express",_),
         m
     ) = (Boolean true, m)
     
-  | E( itree(inode("value",_),
+  | E( itree(inode("Value",_),
                 [
                     itree(inode("false",_), [] )
                 ]
@@ -532,7 +532,7 @@ fun E( itree(inode("Express",_),
         m
     ) = (Boolean false, m)
   
-  | E( itree(inode("value",_),
+  | E( itree(inode("Value",_),
                 [
                     integer
                 ]
@@ -638,13 +638,13 @@ fun M(  itree(inode("prog",_),
                     itree(inode("bool",_), [] ),
                     id_node,
                     itree(inode("=",_), [] ),
-                    expr
+                    Express
                 ]
             ),
         m0
     ) = let
           val id = getLeaf(id_node)
-          val (v, m1) = E(expr, m0)
+          val (v, m1) = E(Express, m0)
           val (_,n,_) = m1
           val m2 = updateEnv(id, BOOL, n, m1)
           val loc = getLoc(accessEnv(id, m2))
@@ -658,13 +658,13 @@ fun M(  itree(inode("prog",_),
                     itree(inode("int",_), [] ),
                     id_node,
                     itree(inode("=",_), [] ),
-                    expr
+                    Express
                 ]
             ),
         m0
     ) = let
           val id = getLeaf(id_node)
-          val (v, m1) = E(expr, m0)
+          val (v, m1) = E(Express, m0)
           val (_,n,_) = m1
           val m2 = updateEnv(id, INT, n, m1)
           val loc = getLoc(accessEnv(id, m2))
@@ -677,13 +677,13 @@ fun M(  itree(inode("prog",_),
                 [
                     id_node,
                     itree(inode("=",_), [] ),
-                    expr
+                    Express
                 ]
             ),
         m0
     ) = let
           val id = getLeaf(id_node)
-          val (v, m1) = E(expr, m0)
+          val (v, m1) = E(Express, m0)
           val loc = getLoc(accessEnv(id, m1))
           val m2 = updateStore(loc, v, m1)
         in
@@ -710,30 +710,30 @@ fun M(  itree(inode("prog",_),
 *)
 
   (* If *)
-  | M( itree(inode("if_stmt", _),
+  | M( itree(inode("If", _),
                 [
                     itree(inode("if",_), [] ),
                     itree(inode("(",_), [] ),
-                    expr,
+                    Express,
                     itree(inode(")",_), [] ),
                     itree(inode("then",_), []),
-                    block
+                    Block
                 ]
              ),
             m0
       ) = let
-               val (v, m1) = E(expr, m0)
+               val (v, m1) = E(Express, m0)
            in
-                if toBool(v) then M(block, m1)
+                if toBool(v) then M(Block, m1)
                 else m1
            end
 
   (* If Else *)
-  | M( itree(inode("if_else", _),
+  | M( itree(inode("IfElse", _),
                   [
                     itree(inode("if",_), [] ),
                     itree(inode("(",_), [] ),
-                    expr,
+                    Express,
                     itree(inode(")",_), [] ),
                     itree(inode("then",_), []),
                     block1,
@@ -743,7 +743,7 @@ fun M(  itree(inode("prog",_),
                ),
               m0
         ) = let
-                 val (v, m1) = E(expr, m0)
+                 val (v, m1) = E(Express, m0)
              in
                   if toBool(v) then M( block1, m1)
                   else M(block2, m1)
@@ -766,7 +766,7 @@ fun M(  itree(inode("prog",_),
           end
           
   (* Iterator *)
-  | M( itree(inode("iter",_),
+  | M( itree(inode("Iter",_),
                 [
                     Iter
                 ]
@@ -843,9 +843,9 @@ fun M(  itree(inode("prog",_),
         end
 
   (* Print *)
-  | M( itree(inode("print", _),
+  | M( itree(inode("Print", _),
                 [
-                    itree(inode("print",_), []),
+                    itree(inode("Print",_), []),
                     itree(inode("(",_), [] ),
                     Express,
                     itree(inode(")",_), [] )

--- a/Transformation/SML_Modules/Interpreter/typeChecker.sml
+++ b/Transformation/SML_Modules/Interpreter/typeChecker.sml
@@ -18,7 +18,7 @@ exception model_error;
 fun typeOf( itree(inode("Express",_),
                 [
                     Express,
-                    itree(inode("or",_), [] ),
+                    itree(inode("||",_), [] ),
                     LogicAnd
                 ]
             ),
@@ -36,7 +36,7 @@ fun typeOf( itree(inode("Express",_),
 | typeOf( itree(inode("LogicalAnd",_),
               [
                   LogicalAnd,
-                  itree(inode("and",_), [] ),
+                  itree(inode("&&",_), [] ),
                   LogicEqual
               ]
           ),

--- a/Transformation/Syntax/lexer.spec
+++ b/Transformation/Syntax/lexer.spec
@@ -31,9 +31,9 @@ fun generateSchemaTokenName( yytext ) =
 %header (functor Target_LexFn(val getNextTokenPos : string -> {line: word, column: word}));
 
 alpha        = [A-Za-z];
-digit           = [0-9];
-posDigit        = [1-9];
-integer         = 0 | {posDigit}{digit}*;
+digit        = [0-9];
+posDigit     = [1-9];
+integer      = 0 | {posDigit}{digit}*;
 alphanumeric = [A-Za-z0-9];
 identifier   = {alpha}{alphanumeric}*;
 ws           = [\  \t \n];
@@ -47,8 +47,7 @@ comment      = "//" .* ;
 {ws}+        => ( getNextTokenPos(yytext); lex()  );
 {comment}    => ( getNextTokenPos(yytext); lex()  );
 
-{digit}+                      => ( SHELL("integer"   , yytext,     getNextTokenPos(yytext))    );
-{alpha}{alphanumeric}*        => ( SHELL("id"        , yytext,     getNextTokenPos(yytext))    );
+
 
 <INITIAL> ";"                       => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 <INITIAL> ","                       => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
@@ -81,21 +80,21 @@ comment      = "//" .* ;
 <INITIAL> "for"                     => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 <INITIAL> "while"                   => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 
-<INITIAL> "&&"                   => ( SHELL(yytext                               , yytext,     getNextTokenPos(yytext))    );
-<INITIAL> "||"                   => ( SHELL(yytext                               , yytext,     getNextTokenPos(yytext))    );
-<INITIAL> "|"                    => ( SHELL(yytext                               , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> "&&"                      => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> "||"                      => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> "|"                       => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 
 <INITIAL> "bool"                    => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 <INITIAL> "int"                     => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 
 <INITIAL> "print"                   => ( SHELL(yytext                            , yytext,     getNextTokenPos(yytext))    );
 
-<INITIAL> {boolean}                 => ( SHELL("bool"                            , yytext,     getNextTokenPos(yytext))    );
-<INITIAL> {integer}                 => ( SHELL("int"                             , yytext,     getNextTokenPos(yytext))    );
-<INITIAL> {identifier}              => ( SHELL("id"                              , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> {boolean}                 => ( SHELL("boolean"                         , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> {integer}                 => ( SHELL("integer"                         , yytext,     getNextTokenPos(yytext))    );
+<INITIAL> {identifier}              => ( SHELL("identifier"                      , yytext,     getNextTokenPos(yytext))    );
 
 
-{schema_id}                   => ( SHELL(generateSchemaTokenName(yytext), yytext, getNextTokenPos(yytext))    );
-"[:]"                         => ( SHELL("" , yytext, getNextTokenPos(yytext))    );
+{schema_id}                         => ( SHELL(generateSchemaTokenName(yytext)   , yytext, getNextTokenPos(yytext))        );
+"[:]"                               => ( SHELL("" ,                                    yytext, getNextTokenPos(yytext))    );
 
- .                            => ( error("ignored an unprintable character: " ^ yytext); getNextTokenPos(yytext); lex()  );
+ .                                  => ( error("ignored an unprintable character: " ^ yytext); getNextTokenPos(yytext); lex()  );

--- a/Transformation/Syntax/mini_language.bnf
+++ b/Transformation/Syntax/mini_language.bnf
@@ -89,7 +89,7 @@ prog
                         | <IncrDecr> 
                         | <Value>                                                                       .
 
-<value>              ::= integer 
+<Value>              ::= integer 
                         | boolean                                                                       .
 
 <Print>              ::= "print" "(" <Express> ")"                                                      .


### PR DESCRIPTION
`three_x_plus_1_v3.tgt `

```
Target program parse failed.
Every alternative failed to parse.  A list of syntax errors follows:
  Line 82.17:  Unexpected input '&&'.  Expected: '', '%', ')', '*', '+', '-', '/', '<', '>', '^', '!=', '<=', '==', '>=', '||'

```